### PR TITLE
Changed Dockerfile to be compatible with Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY . .
 RUN cargo build --release
 
 # Now make the runtime container
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim AS runtime
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y openssl ca-certificates git subversion make autoconf automake libtool pkg-config g++ && \


### PR DESCRIPTION
The latest TTS Service on Docker Hub gaves me GLIBC errors. Changing the bullseye to bookworm solves the issue for me. https://github.com/LukeMathWalker/cargo-chef/issues/188